### PR TITLE
improve message_retrier call timeout

### DIFF
--- a/lib/message_broker/consumer/message_retrier.ex
+++ b/lib/message_broker/consumer/message_retrier.ex
@@ -41,7 +41,7 @@ defmodule MessageBroker.Consumer.MessageRetrier do
             ) ::
               {:ok, :message_retried} | {:error, :message_retries_expired} | {:error, any()}
   def retry_message(module, message, headers) do
-    case GenServer.call(module, {:retry, message, headers}) do
+    case GenServer.call(module, {:retry, message, headers}, 15_000) do
       :ok -> {:ok, :message_retried}
       error -> error
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MessageBroker.MixProject do
   def project do
     [
       app: :message_broker,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Improve MessageRetrier call timeout

**Why is this change necessary?**

- MessageRetrier is exiting because of timeout in production environments.

**How does it address the issue?**

- Increase the default timeout (5s) to 15s.

**What side effects does this change have?**

- N/A