### PR TITLE
Change MessageRetrier Queue creation

### DIFF
--- a/lib/message_broker/consumer/message_retrier.ex
+++ b/lib/message_broker/consumer/message_retrier.ex
@@ -6,6 +6,7 @@ defmodule MessageBroker.Consumer.MessageRetrier do
   use MessageBroker.RabbitmqServer, as: "MessageRetrier", name_key: :message_retrier_name
 
   alias AMQP.Basic
+  alias MessageBroker.Consumer.MessageRetrierHelper, as: Helper
 
   @impl GenServer
   def init(
@@ -62,46 +63,15 @@ defmodule MessageBroker.Consumer.MessageRetrier do
          rabbitmq_queue: queue,
          rabbitmq_retries_count: max_retries
        }) do
-    retries_count = death_count(headers)
+    retries_count = Helper.death_count(headers)
 
     if retries_count < max_retries do
-      delay = exponential_delay_milliseconds(retries_count)
-      routing_key = "#{queue}.#{delay}"
-
-      {:ok, %{queue: retry_queue}} = create_retry_queue(channel, queue, delay)
-      :ok = Queue.bind(channel, retry_queue, exchange, routing_key: routing_key)
+      delay = Helper.exponential_delay_milliseconds(retries_count)
+      routing_key = Helper.routing_key(queue, delay)
 
       Basic.publish(channel, exchange, routing_key, message, headers: headers, persistent: true)
     else
       {:error, :message_retries_expired}
     end
-  end
-
-  defp death_count(:undefined), do: 0
-
-  defp death_count(headers) do
-    {_, _, tables} = Enum.find(headers, {"x-death", :long, []}, &({"x-death", _, _} = &1))
-
-    Enum.reduce(tables, 0, fn {:table, values}, acc ->
-      {_, _, count} = Enum.find(values, {"count", :long, 0}, &({"count", _, _} = &1))
-      acc + count
-    end)
-  end
-
-  defp exponential_delay_milliseconds(retries), do: pow(retries + 1, 2) * 1000
-
-  defp pow(base, 1), do: base
-  defp pow(base, exp), do: base * pow(base, exp - 1)
-
-  defp create_retry_queue(channel, queue, delay) do
-    Queue.declare(channel, "#{queue}.retry.#{delay}",
-      durable: true,
-      arguments: [
-        {"x-dead-letter-exchange", :longstr, ""},
-        {"x-dead-letter-routing-key", :longstr, queue},
-        {"x-message-ttl", :long, delay},
-        {"x-expires", :long, delay * 2}
-      ]
-    )
   end
 end

--- a/lib/message_broker/consumer/message_retrier_helper.ex
+++ b/lib/message_broker/consumer/message_retrier_helper.ex
@@ -1,0 +1,62 @@
+defmodule MessageBroker.Consumer.MessageRetrierHelper do
+  @moduledoc """
+  Helper functions for MessageRetrier.
+  """
+
+  @doc """
+  Get death count from RabbitMQ message headers.
+
+  ## Examples
+
+    iex> death_count([{"x-death", :long, []}, ...])
+    0
+
+    iex> death_count([{"x-death", :long, [{:table, [{"count", :long, 1}, ...]}, ...]}, ...])
+    1
+  """
+  def death_count(headers)
+  def death_count(:undefined), do: 0
+
+  def death_count(headers) do
+    {_, _, tables} = Enum.find(headers, {"x-death", :long, []}, &({"x-death", _, _} = &1))
+
+    Enum.reduce(tables, 0, fn {:table, values}, acc ->
+      {_, _, count} = Enum.find(values, {"count", :long, 0}, &({"count", _, _} = &1))
+      acc + count
+    end)
+  end
+
+  @doc """
+  Return exponential delay in milliseconds based in attempted retries.
+
+  ## Examples
+
+    iex> exponential_delay_milliseconds(-1)
+    0
+
+    iex> exponential_delay_milliseconds(0)
+    1_000
+
+    iex> exponential_delay_milliseconds(2)
+    9_000
+
+  """
+  def exponential_delay_milliseconds(attempted_retries)
+  def exponential_delay_milliseconds(attempted_retries) when attempted_retries < 0, do: 0
+
+  def exponential_delay_milliseconds(attempted_retries) when attempted_retries >= 0 do
+    retries = attempted_retries + 1
+    retries * retries * 1000
+  end
+
+  @doc """
+  Message's Routing Key with delay.
+
+  ## Examples
+
+    iex> routing_key("my_app.my_queue", 1000)
+    "my_app.my_queue.1000"
+
+  """
+  def routing_key(queue, delay), do: "#{queue}.#{delay}"
+end

--- a/lib/message_broker/consumer/setup.ex
+++ b/lib/message_broker/consumer/setup.ex
@@ -9,6 +9,8 @@ defmodule MessageBroker.Consumer.Setup do
 
   require Logger
 
+  alias MessageBroker.Consumer.MessageRetrierHelper
+
   @doc """
   Initialize Consumer in RabbitMQ server.
   """
@@ -19,7 +21,8 @@ defmodule MessageBroker.Consumer.Setup do
           rabbitmq_host: host,
           rabbitmq_exchange: exchange,
           rabbitmq_queue: queue,
-          rabbitmq_subscribed_topics: subscribed_topics
+          rabbitmq_subscribed_topics: subscribed_topics,
+          rabbitmq_retries_count: retries_count
         } = config
       ) do
     Logger.info("Connecting to RabbitMQ to setup topics for queue.")
@@ -27,7 +30,7 @@ defmodule MessageBroker.Consumer.Setup do
     case rabbitmq_connection(user, password, host) do
       {:ok, conn} ->
         {:ok, chan} = Channel.open(conn)
-        setup_queue(chan, exchange, queue, subscribed_topics)
+        setup_queue(chan, exchange, queue, subscribed_topics, retries_count)
 
       {:error, error} ->
         Logger.error(
@@ -43,7 +46,7 @@ defmodule MessageBroker.Consumer.Setup do
     Connection.open(username: user, password: password, host: host, virtual_host: "/")
   end
 
-  defp setup_queue(chan, exchange, queue, subscribed_topics) do
+  defp setup_queue(chan, exchange, queue, subscribed_topics, retries_count) do
     queue_error = "#{queue}_error"
 
     {:ok, _} = Queue.declare(chan, queue_error, durable: true)
@@ -63,5 +66,34 @@ defmodule MessageBroker.Consumer.Setup do
     for topic <- subscribed_topics do
       :ok = Queue.bind(chan, queue, exchange, routing_key: topic)
     end
+
+    create_retry_queues(retries_count, chan, exchange, queue)
+  end
+
+  defp create_retry_queues(retries_count, channel, exchange, queue)
+
+  defp create_retry_queues(retries_count, _channel, _exchange, _queue) when retries_count < 1,
+    do: :ok
+
+  defp create_retry_queues(retries_count, channel, exchange, queue) when retries_count > 0 do
+    Enum.each(1..retries_count, fn count ->
+      delay = MessageRetrierHelper.exponential_delay_milliseconds(count - 1)
+      create_retry_queue(channel, exchange, queue, delay)
+    end)
+  end
+
+  defp create_retry_queue(channel, exchange, queue, delay) do
+    {:ok, %{queue: retry_queue}} =
+      Queue.declare(channel, "#{queue}.retry.#{delay}",
+        durable: true,
+        arguments: [
+          {"x-dead-letter-exchange", :longstr, ""},
+          {"x-dead-letter-routing-key", :longstr, queue},
+          {"x-message-ttl", :long, delay}
+        ]
+      )
+
+    routing_key = MessageRetrierHelper.routing_key(queue, delay)
+    :ok = Queue.bind(channel, retry_queue, exchange, routing_key: routing_key)
   end
 end

--- a/test/message_broker/consumer/message_retrier_helper_test.exs
+++ b/test/message_broker/consumer/message_retrier_helper_test.exs
@@ -1,0 +1,60 @@
+defmodule MessageBroker.Consumer.MessageRetrierHelperTest do
+  use ExUnit.Case
+
+  alias MessageBroker.Consumer.MessageRetrierHelper, as: Helper
+
+  describe "#death_count/1" do
+    defp death_count_headers(count)
+    defp death_count_headers(0), do: [{"x-death", :long, []}]
+
+    defp death_count_headers(count) when count > 0 do
+      count_values =
+        Enum.reduce(0..(count - 1), [], fn _, acc ->
+          acc ++ [{:table, [{"count", :long, 1}, {"some_value", :long, Enum.random(1..1000)}]}]
+        end)
+
+      [{"x-death", :long, count_values}]
+    end
+
+    test "for undefined headers returns 0" do
+      assert 0 == Helper.death_count(:undefined)
+    end
+
+    test "for headers with 0 counts" do
+      headers = death_count_headers(0)
+
+      assert 0 == Helper.death_count(headers)
+    end
+
+    test "for headers with 1 count" do
+      headers = death_count_headers(1)
+
+      assert 1 == Helper.death_count(headers)
+    end
+
+    test "for headers with more than 1 count" do
+      count = Enum.random(2..1000)
+      headers = death_count_headers(count)
+
+      assert count == Helper.death_count(headers)
+    end
+  end
+
+  describe "#exponential_delay_milliseconds/1" do
+    test "for retries below 0" do
+      assert 0 == Helper.exponential_delay_milliseconds(Enum.random(-1..-1000))
+    end
+
+    test "for retries above -1" do
+      assert 1_000 == Helper.exponential_delay_milliseconds(0)
+      assert 9_000 == Helper.exponential_delay_milliseconds(2)
+      assert 10_000_000 == Helper.exponential_delay_milliseconds(99)
+    end
+  end
+
+  describe "#routing_key/2" do
+    test "properly returns the queue" do
+      assert "my_app.my_queue.1000" == Helper.routing_key("my_app.my_queue", 1000)
+    end
+  end
+end


### PR DESCRIPTION
Change MessageRetrier Queue creation

**Why is this change necessary?**

- MessageRetrier is exiting because timeout error.

**How does it address the issue?**

- Create retry queues when application starts to improve retry message publishing.

**What side effects does this change have?**

- N/A