### PR TITLE
add valid tuple to message_handler response

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ end
 ```
 
 Then you must define a function that receives the events consumed.
-If the event is successfully consumed you must return `:ok`, anything else is an error.
+If the event is successfully consumed you must return `:ok` or `{:ok, any()}`, anything else is an error.
 
 ```elixir
 defmodule MyApp.MessageHandler do
@@ -84,7 +84,7 @@ defmodule MyApp.MessageHandler do
   Consumer MessageHandler.
   """
 
-  @callback handle_message(map(), map()) :: :ok | any()
+  @callback handle_message(map(), map()) :: :ok | {:ok, any()} | any()
   def handle_message(%{"event" => name, "payload" => payload} = event, _metadata) do
     case name do
       "some_app.some_schema.action" ->

--- a/lib/message_broker/consumer.ex
+++ b/lib/message_broker/consumer.ex
@@ -62,9 +62,13 @@ defmodule MessageBroker.Consumer do
       when is_function(message_handler) do
     headers = Map.get(metadata, :headers)
 
-    case message_handler.(decode_data(data), metadata) do
-      :ok -> message
-      {:ok, _} -> message
+    try do
+      case message_handler.(decode_data(data), metadata) do
+        :ok -> message
+        {:ok, _} -> message
+        error -> handle_failed_message(message, error, data, headers, message_retrier_name)
+      end
+    rescue
       error -> handle_failed_message(message, error, data, headers, message_retrier_name)
     end
   end

--- a/lib/message_broker/consumer.ex
+++ b/lib/message_broker/consumer.ex
@@ -64,6 +64,7 @@ defmodule MessageBroker.Consumer do
 
     case message_handler.(decode_data(data), metadata) do
       :ok -> message
+      {:ok, _} -> message
       error -> handle_failed_message(message, error, data, headers, message_retrier_name)
     end
   end

--- a/lib/message_broker/message_handler.ex
+++ b/lib/message_broker/message_handler.ex
@@ -3,6 +3,6 @@ defmodule MessageBroker.MessageHandler do
   Stub for Consumer MessageHandler.
   """
 
-  @callback handle_message(map(), map()) :: :ok | any()
+  @callback handle_message(map(), map()) :: :ok | {:ok, any()} | any()
   def handle_message(_, _), do: raise("Implement MessageHandler for MessageBroker Consumer!")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MessageBroker.MixProject do
   def project do
     [
       app: :message_broker,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/message_broker/consumer/consumer_test.exs
+++ b/test/message_broker/consumer/consumer_test.exs
@@ -45,6 +45,14 @@ defmodule MessageBroker.ConsumerTest do
                  message_retrier_name: MessageBroker.Internal.SomeMessageRetrier
                })
 
+      expect(MessageHandlerMock, :handle_message, 1, fn ^decoded_json, ^metadata -> {:ok, %{}} end)
+
+      assert ^message =
+               MyConsumer.handle_message(nil, message, %{
+                 message_handler: &MessageBroker.MessageHandlerMock.handle_message/2,
+                 message_retrier_name: MessageBroker.Internal.SomeMessageRetrier
+               })
+
       stop_supervisor(pid)
     end
 

--- a/test/message_broker/consumer/consumer_test.exs
+++ b/test/message_broker/consumer/consumer_test.exs
@@ -63,9 +63,14 @@ defmodule MessageBroker.ConsumerTest do
       :ok = send_rabbitmq_message(chan, @exchange, @queue, @topic, message_payload)
 
       # MessageHandler always fail to trigger retries and dead-letter queue
-      expect(MessageHandlerMock, :handle_message, 4, fn payload, _ ->
+      expect(MessageHandlerMock, :handle_message, 2, fn payload, _ ->
         assert payload == Jason.decode!(message_payload)
         {:error, "some error"}
+      end)
+
+      expect(MessageHandlerMock, :handle_message, 2, fn payload, _ ->
+        assert payload == Jason.decode!(message_payload)
+        raise("some error")
       end)
 
       # Wait exponential time for 3 retry counts (1s + 4s + 9s =~ 15s)


### PR DESCRIPTION
add valid tuple to message_handler response and rescue exceptions

**Why is this change necessary?**

- Most of our consumers respond with {:ok, changes} when successfully consumes an event.
- When message_handler raise an exception, the message is lost and not retried.

**How does it address the issue?**

- Accept {:ok, any()} as valid response from message_handler.
- Rescue exceptions from message_handler to properly retry the message.

**What side effects does this change have?**

- N/A

**Task card (link)**

- N/A