### PR TITLE
display exception messages for #handle_message/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MessageBroker can be installed by adding `message_broker` to your list of depend
 ```elixir
 def deps do
   [
-    {:message_broker, git: "https://github.com/bcredi/message_broker.git", tag: "v0.1.2"}
+    {:message_broker, git: "https://github.com/bcredi/message_broker.git", tag: "v0.1.3"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MessageBroker.MixProject do
   def project do
     [
       app: :message_broker,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
display exception messages for #handle_message/2

**Why is this change necessary?**

- Consumer #handle_message/2 isn't display error messages for exceptions.

**How does it address the issue?**

- Log #handle_message/2 exceptions as error.

**What side effects does this change have?**

- N/A

**Task card (link)**

- N/A